### PR TITLE
fix: browser console error for toggle-button.blade.php

### DIFF
--- a/resources/views/components/toggle-button.blade.php
+++ b/resources/views/components/toggle-button.blade.php
@@ -43,8 +43,10 @@
             {{ $onLabel }}
             <input
                 type="radio"
-                x-model="state"
-                class="absolute left-0 opacity-0"
+                name="{{ $id }}"
+                id="{{ $id }}-{{ $onLabel }}"
+                value="true"
+                class="sr-only"
             />
         </label>
 
@@ -76,8 +78,10 @@
             {{ $offLabel }}
             <input
                 type="radio"
-                x-model="!state"
-                class="absolute left-0 opacity-0"
+                name="{{ $id }}"
+                id="{{ $id }}-{{ $offLabel }}"
+                value="false"
+                class="sr-only"
             />
         </label>
     </div>


### PR DESCRIPTION
Fix console error caused by negating the state of the toggle button, and add support for keyboard navigation for toggle button.