### PR TITLE
Adjust grid layout for better responsiveness

### DIFF
--- a/resources/views/components/button-group.blade.php
+++ b/resources/views/components/button-group.blade.php
@@ -1,22 +1,21 @@
+@php
+    $id = $getId();
+    $statePath = $getStatePath();
+    $isDisabled = $isDisabled();
+    $options = $getOptions();
+    $offColor = $getOffColor() ?? 'gray';
+    $onColor = $getOnColor() ?? 'primary';
+    $gridDirection = $getGridDirection() ?? 'column';
+    $icons = $getIcons();
+    $iconPosition = $getIconPosition();
+    $iconSize = $getIconSize();
+@endphp
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $id = $getId();
-        $statePath = $getStatePath();
-        $isDisabled = $isDisabled();
-        $options = $getOptions();
-        $offColor = $getOffColor() ?? 'gray';
-        $onColor = $getOnColor() ?? 'primary';
-        $gridDirection = $getGridDirection() ?? 'column';
-        $icons = $getIcons();
-        $iconPosition = $getIconPosition();
-        $iconSize = $getIconSize();
-    @endphp
-
     <div
         @class([
-            'selectify-button-group-grid',
-            'grid grid-flow-row grid-cols-2 gap-3' => $gridDirection === 'row',
-            'grid grid-flow-col grid-rows-2 gap-3' => $gridDirection === 'column',
+            'selectify-button-group-grid grid gap-3',
+            'grid-cols-1 sm:grid-cols-2' => $gridDirection === 'row',
+            'sm:grid-flow-col sm:grid-rows-2' => $gridDirection === 'column',
         ])
         x-data="{
             state: $wire.{{ $applyStateBindingModifiers("entangle('{$statePath}')") }},
@@ -29,11 +28,12 @@
     >
         @foreach ($options as $value => $label)
             @php
+                $inputId = "{$id}-{$value}";
                 $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
             @endphp
 
             <label
-                for="{{ $id }}-{{ $value }}"
+                for="{{ $inputId }}"
                 x-on:click="state = '{{ $value }}'"
                 x-bind:class="
                     state == '{{ $value }}'
@@ -61,10 +61,10 @@
                 <input
                     type="radio"
                     name="{{ $id }}"
-                    id="{{ $id }}-{{ $value }}"
+                    id="{{ $inputId }}"
                     value="{{ $value }}"
                     class="sr-only"
-                    aria-labelledby="{{ $id }}-{{ $value }}"
+                    aria-labelledby="{{ $inputId }}"
                     @disabled($shouldOptionBeDisabled)
                     wire:loading.attr="disabled"
                 />

--- a/src/Components/ButtonGroup.php
+++ b/src/Components/ButtonGroup.php
@@ -13,10 +13,10 @@ use Filament\Support\Enums\IconSize;
 
 class ButtonGroup extends Field
 {
+    use HasExtraAlpineAttributes;
+    use HasGridDirection;
     use HasOptions;
     use HasToggleColors;
-    use HasGridDirection;
-    use HasExtraAlpineAttributes;
 
     protected string $view = 'filament-selectify::components.button-group';
 
@@ -28,7 +28,7 @@ class ButtonGroup extends Field
 
     protected IconSize | string | Closure | null $iconSize = null;
 
-    public function boolean(string | null $trueLabel = null, string | null $falseLabel = null): static
+    public function boolean(?string $trueLabel = null, ?string $falseLabel = null): static
     {
         $this->options([
             true => $trueLabel ?? 'Yes',


### PR DESCRIPTION
Fixes #15. Adjusted grid layout for better responsiveness on small screens. Probably will use `<x-filament::grid>` component in the future to give the user better control over how many columns they want Button groups to span.