### PR TITLE
Filament v4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,10 @@ php artisan vendor:publish --tag="filament-selectify-views"
 
 ## Registering Styles
 
-In order for component styles to be processed, you must add this package's vendor directory into the content array of your `tailwind.config.js` file:
-```php
-export default {
-    content: [
-        './resources/**/*.blade.php',
-        './vendor/filament/**/*.blade.php',
-        './vendor/andrewdwallo/filament-selectify/resources/views/**/*.blade.php', // The package's vendor directory
-    ],
-    // ...
-}
+In order for the component's styles to be processed, you must add this package's vendor directory into your panels custom `theme.css` file. You can see how to create a Filament PHP custom theme [here](https://filamentphp.com/docs/admin/themes#custom-themes).
+
+```css
+@source '../../../../vendor/andrewdwallo/filament-selectify/resources/views';
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A small package featuring two simple components that serve as excellent alternat
 ![ToggleButton](https://github.com/andrewdwallo/filament-selectify/assets/104294090/08f7439c-c20d-4d1b-b105-a71d08cc5c94)
 
 <p align="center">
-    <a href="https://filamentadmin.com/docs/2.x/admin/installation">
-        <img alt="FILAMENT 8.x" src="https://img.shields.io/badge/FILAMENT-2.x-EBB304?style=for-the-badge">
+    <a href="https://filamentphp.com">
+        <img alt="FILAMENT 4.x" src="https://img.shields.io/badge/FILAMENT-4.x-EBB304?style=for-the-badge">
     </a>
     <a href="https://packagist.org/packages/andrewdwallo/filament-selectify">
         <img alt="Packagist" src="https://img.shields.io/packagist/v/andrewdwallo/filament-selectify.svg?style=for-the-badge&logo=packagist">

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "filament/forms": "^3.0",
+        "php": "^8.2",
+        "filament/forms": "^4.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9",
-        "orchestra/testbench": "^8.0",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0"

--- a/tests/ButtonTest.php
+++ b/tests/ButtonTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Wallo\FilamentSelectify\Components\ButtonGroup;
+use Wallo\FilamentSelectify\Components\ToggleButton;
+
+it('button group component can be instantiated', function () {
+    $component = ButtonGroup::make('test')
+        ->options(['yes' => 'Yes', 'no' => 'No'])
+        ->onColor('primary')
+        ->offColor('gray');
+
+    expect($component)->toBeInstanceOf(ButtonGroup::class);
+    expect($component->getOptions())->toBe(['yes' => 'Yes', 'no' => 'No']);
+});
+
+it('toggle button component can be instantiated', function () {
+    $component = ToggleButton::make('active')
+        ->onLabel('Enabled')
+        ->offLabel('Disabled')
+        ->onColor('success')
+        ->offColor('danger');
+
+    expect($component)->toBeInstanceOf(ToggleButton::class);
+    expect($component->getOnLabel())->toBe('Enabled');
+    expect($component->getOffLabel())->toBe('Disabled');
+});
+
+it('button group boolean method works', function () {
+    $component = ButtonGroup::make('test')->boolean('Active', 'Inactive');
+
+    expect($component->getOptions())->toBe([true => 'Active', false => 'Inactive']);
+});

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('can test', function () {
-    expect(true)->toBeTrue();
-});


### PR DESCRIPTION
### Updated for Filament v4 Compatibility

- Updated minimum PHP version to 8.2
- Updated Filament dependency to require v4.0+
- Updated development dependencies for Laravel 11/Filament v4 compatibility
- Updated README badge to reflect Filament v4 support
- Confirmed all component classes work with Filament v4 APIs
- Added Button instantiation tests
- All existing functionality remains unchanged

### Breaking Changes

- Dropped support for Filament v3
- Minimum PHP version is now 8.2